### PR TITLE
Fixed missing semicolom to append paths.

### DIFF
--- a/generator/generator.lua
+++ b/generator/generator.lua
@@ -82,7 +82,7 @@ end
 --helper functions
 --------------------------------functions for C generation
 --load parser module
-package.path = package.path.."../../cimgui/generator/?.lua"
+package.path = package.path .. ";../../cimgui/generator/?.lua"
 local cpp2ffi = require"cpp2ffi"
 local read_data = cpp2ffi.read_data
 local save_data = cpp2ffi.save_data


### PR DESCRIPTION
The cimplot generator.lua could not find cpp2ffi.lua from cimgui while running generator.sh from the generator directory. This was due to a missing seperator in the pathfile. The path (../../cimgui/generator/?.lua) would just append to the last entry instead of being a seperate entry. 



- projectdir
  - cimgui
    -generator 
    -imgui
  - cimplot
    -generator   
    -cimplot