### PR TITLE
fix: shebang /usr/bin/sh to /bin/sh for MacOS

### DIFF
--- a/generator/generator.sh
+++ b/generator/generator.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 
 # this script must be executed in this directory
 # all the output goes to generator/output folder


### PR DESCRIPTION
when giving `#!/usr/bin/sh` it looks for user's sh binary which doesn't present in MacOS systems, changing `#!/usr/bin/sh` to `#!/bin/sh` will add compatibility to MacOS also since `/usr/bin` is a user-related location for most Linux distributions it would be better pratice to look at to system's binary location which is `/bin`